### PR TITLE
Update links that redirect / remove those who return 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@
 * https://bitsofco.de/the-accessibility-cheatsheet/
 * https://a11yweekly.com/
 * https://axesslab.com/ 
-* https://resources.emailmonks.com/infographics/emails-accessibility-best-practices.html
+* https://email.uplers.com/infographics/emails-accessibility-best-practices/
 * [24 days of digital accessibility gifts during the season of giving and sharing](https://www.24a11y.com/)
 * https://www.campaignmonitor.com/resources/guides/accessibility/
 * https://www.emailonacid.com/resource/email-accessibility-infographic/

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 ## Articles
 * https://www.campaignmonitor.com/resources/guides/accessibility/
 * https://litmus.com/blog/ultimate-guide-accessible-emails
-* https://www.emailonacid.com/blog/article/email-development/email-accessibilty-in-2017
+* https://www.emailonacid.com/blog/article/email-development/email-accessibilty-in-2017/
 * https://mailchimp.com/resources/accessibility-in-email-marketing/
 * http://kb.mailchimp.com/campaigns/previews-and-tests/accessibility-in-email-marketing
 * http://eroi.com/10-tips-on-accessible-email/
-* http://www.bbc.co.uk/gel/guidelines/how-to-design-accessible-email-newsletters
+* https://www.bbc.co.uk/gel/guidelines/how-to-design-accessible-email-newsletters
 * https://www.frankwatching.com/archive/2017/02/02/4-aspecten-waarmee-je-jouw-e-mailnieuwsbrieven-toegankelijker-maakt/ [Dutch]
 * https://www.frankwatching.com/archive/2017/02/09/6-oplossingen-om-je-nieuwsbrief-nog-toegankelijker-te-maken/ [Dutch]
 * https://www.emerce.nl/achtergrond/inclusive-design-maakt-e-mail-toegankelijk-voor-iedereen [Dutch]
@@ -18,10 +18,10 @@
 * https://axesslab.com/accessibility-according-to-pwd/
 * https://axesslab.com/alt-texts/
 * https://axesslab.com/trends/
-* https://silktide.com/i-thought-title-text-improved-accessibility-i-was-wrong/
+* https://silktide.com/blog/accessibility/i-thought-title-text-improved-accessibility-i-was-wrong/
 * https://css-tricks.com/html-email-accessibility/
 * https://css-tricks.com/small-tweaks-can-make-huge-impact-websites-accessibility/
-* https://emails.hteumeuleu.com/email-accessibility-in-action-f7f9d945cf67
+* https://www.hteumeuleu.com/2018/email-accessibility-in-action/
 * https://axesslab.com/title-texts-suck/
 * https://axesslab.com/text-splitting/
 * https://axesslab.com/hand-tremors/
@@ -34,12 +34,12 @@
 * https://webdesign.tutsplus.com/tutorials/a-beginners-guide-to-email-accessibility--cms-31240
 * https://www.24a11y.com/2018/accessibility-and-inclusion-with-email/
 * https://www.invisionapp.com/inside-design/why-digital-accessibility-matters/
-* https://litmus.com/blog/7-simple-tricks-to-make-your-email-code-more-accessible
+* https://www.litmus.com/blog/7-simple-tricks-to-make-your-email-code-more-accessible/
 * https://optinmonster.com/why-ignoring-email-accessibility-is-hurting-your-business/
 * https://www.onlyinfluencers.com/email-marketing-blog-posts/best-practice-email-strategy/entry/the-difference-between-accessibility-and-inclusion-in-email-marketing
 * https://explore.reallygoodemails.com/email-accessibility-looks-arent-everything-ad0b1f6af0a4
-* https://litmus.com/blog/accessibility-vs-inclusion-what-it-takes-to-create-more-inclusive-email-marketing-experiences
-* http://www.emaildesignreview.com/email-industry-insight/accessibility-in-digital-marketing-4148/
+* https://www.litmus.com/blog/accessibility-vs-inclusion-what-it-takes-to-create-more-inclusive-email-marketing-experiences/
+* http://www.emaildesignreview.com/uncategorized/accessibility-in-digital-marketing-4148/
 * https://uxmovement.com/buttons/the-myths-of-color-contrast-accessibility/
 * https://the-pastry-box-project.net/anne-gibson/2014-july-31
 * https://amarachiazubuike.com/a-beginners-guide-to-web-accessibility-ckelka23j00cd8cs10h24byf7
@@ -58,45 +58,42 @@
 * [Email Accessibility Resources](https://docs.google.com/document/d/1wKvh0cpzwwnU5JsN8EnHNW2_PlrknzBQkPPqXGiZRcI/edit) [Google Doc]
 * [Email Accessibility Tips from the Pros](https://litmus.com/resources/email-accessibility-tips-from-the-pros) [VIDEO]
 * [Accessibility in AMP](https://www.youtube.com/watch?v=XPdmigsP0Sw&feature=youtu.be&t=2563) [VIDEO]
-* [Email Accessibility: Fulfill Your Legal Responsibilities and Expand Your Reach](https://blogs.oracle.com/marketingcloud/email-accessibility-fulfill-your-legal-responsibilities-and-expand-your-reach) [VIDEO]
+* [Email Accessibility: Fulfill Your Legal Responsibilities and Expand Your Reach](https://blogs.oracle.com/marketingcloud/post/email-accessibility-fulfill-your-legal-responsibilities-and-expand-your-reach) [VIDEO]
 * https://www.slideshare.net/StacyCarston/emails-how-to-make-ancient-html-accessible
 
 ## Tools
-* http://www.accessible-email.org/
-* http://webaim.org/resources/contrastchecker/
-* https://achecker.ca/checker/index.php
-* http://www.checkmycolours.com/
+* https://www.accessible-email.org/
+* https://webaim.org/resources/contrastchecker/
 * [VoiceOver Cheatsheet](https://twitter.com/mayabenari/status/822241555142426625)
-* [Text alternatives - a decision tree](http://4syllables.com.au/articles/text-alternatives-decision-tree/)
+* [Text alternatives - a decision tree](https://4syllables.com.au/articles/text-alternatives-decision-tree/)
 * [An ongoing project to try and curate beautiful color palettes that are a11y friendly](https://www.randoma11y.com/)
-* [Funkify - Plugin for Chrome that helps you experience the web and interfaces through the eyes of extreme users with different abilities and disabilities](http://www.funkify.org/)
-* https://itunes.apple.com/app/contrast/id1254981365?mt=12&ign-mpt=uo%3D6
+* [Funkify - Plugin for Chrome that helps you experience the web and interfaces through the eyes of extreme users with different abilities and disabilities](https://www.funkify.org/)
+* https://apps.apple.com/app/contrast/id1254981365?ign-mpt=uo%3D6&mt=12
 * http://colororacle.org/
-* http://accessible-colors.com/
-* [Accessibility Checklist](https://www.hhs.gov/web/section-508/making-files-accessible/checklist/email-508-checklist/index.html)
+* https://accessible-colors.com/
 * [Accessible Brand Colors - A tool that evaluates the ADA compliance of your brand’s color palette](https://abc.useallfive.com/)
 * [Email on Acid Accessibility Check](https://d1cr57qij2cwzh.cloudfront.net/wp-content/uploads/2018/11/Campaign-Precheck-Accessibility-Help-Center-Doc.pdf)
-* [Litmus Accessibility Check](https://litmus.com/blog/accessible-email-made-easy-introducing-accessibility-checks-in-litmus)
+* [Litmus Accessibility Check](https://www.litmus.com/blog/accessible-email-made-easy-introducing-accessibility-checks-in-litmus/)
 * [Leonardo: an open source contrast-based color generator](https://medium.com/@NateBaldwin/leonardo-an-open-source-contrast-based-color-generator-92d61b6521d2)
 * [a11yresources - A growing list of accessibility tools and resources](https://a11yresources.webflow.io/category/emails)
 * [axe Accessibility Linter for VS Code](https://www.deque.com/blog/shift-further-left-with-deques-axe-linter-for-vs-code/)
 * [A Complete Guide To Accessibility Tooling](https://www.smashingmagazine.com/2021/06/complete-guide-accessibility-tooling/)
 
 ## Resources
-* https://www.microsoft.com/en-us/Design/inclusive
-* https://www.smashingmagazine.com/tag/accessibility/
+* https://www.microsoft.com/design
+* https://www.smashingmagazine.com/category/accessibility
 * https://axesslab.com/accessibility-according-to-pwd/
 * [Tips from Hugo Giraudel](https://twitter.com/i/moments/877084869309980672)
 * https://accessibility.blog.gov.uk/2016/09/02/dos-and-donts-on-designing-for-accessibility/
 * https://bitsofco.de/the-accessibility-cheatsheet/
-* http://a11yweekly.com/
+* https://a11yweekly.com/
 * https://axesslab.com/ 
 * https://resources.emailmonks.com/infographics/emails-accessibility-best-practices.html
 * [24 days of digital accessibility gifts during the season of giving and sharing](https://www.24a11y.com/)
 * https://www.campaignmonitor.com/resources/guides/accessibility/
 * https://www.emailonacid.com/resource/email-accessibility-infographic/
-* https://litmus.com/blog/the-ultimate-guide-to-email-accessibility-making-emails-for-everyone
-* https://www.emailonacid.com/blog/article/industry-news/accessibility-standards-in-email-marketing/
+* https://www.litmus.com/blog/the-ultimate-guide-to-email-accessibility-making-emails-for-everyone/
+* https://www.emailonacid.com/blog/article/email-development/email-accessibilty-in-2017/
 * https://a11ysupport.io/
 * [a11yresources - A growing list of accessibility tools and resource](https://a11yresources.webflow.io/category/emails)
 * [A Designers Accessibility Checklist](https://www.actionrocket.co/email-design-review/designerchecklist)
@@ -109,12 +106,12 @@
 * **[Episode 4 - Email accessibility testing and tools](https://trailhead.salesforce.com/live/videos/a2r3k000001vD6F/episode-4-email-accessibility-testing-and-tools) NEW**
 
 ## Books
-* https://www.smashingmagazine.com/inclusive-design-patterns/
+* https://www.smashingmagazine.com/2016/10/inclusive-design-patterns/
 * https://abookapart.com/products/accessibility-for-everyone
 
 ## Webinars/Podcasts
 * https://www.emailonacid.com/resource/accessibility-in-email/
-* https://litmus.com/blog/email-design-podcast-73-5-tips-for-making-more-accessible-emails
+* https://www.litmus.com/blog/email-design-podcast-73-5-tips-for-making-more-accessible-emails/
 * https://www.emailonacid.com/resource/email-accessibility-net-atlantic/
-* https://litmus.com/blog/delivering-episode-7-why-is-digital-accessibility-so-important
-* https://litmus.com/webinars/email-accessibility-how-to-make-email-for-everyone-in-3-easy-steps
+* https://www.litmus.com/blog/delivering-episode-7-why-is-digital-accessibility-so-important/
+* https://www.litmus.com/resources/email-accessibility-how-to-make-email-for-everyone-in-3-easy-steps/


### PR DESCRIPTION
I ran a link check: https://validator.w3.org/checklink?uri=https%3A%2F%2Fgithub.com%2Fwilbertheinen%2Faccessible-email-documentation&hide_type=all&depth=&check=Check

Many URLs redirect from http:// to https://, or has changed in other ways, updating those.

The following return 404s and have been removed:
- https://achecker.ca/checker/index.php
- https://www.hhs.gov/web/section-508/making-files-accessible/checklist/email-508-checklist/index.html
- http://www.checkmycolours.com/ (no 404, but states the service is discontinued)